### PR TITLE
[CU-86ewvp51k] Simplify try executor and fix PullImages nil dereference

### DIFF
--- a/docker_executor/docker.go
+++ b/docker_executor/docker.go
@@ -82,6 +82,9 @@ func (d *DockerClient) PullImages(images []DockerImageReference) []error {
 			})
 			if err != nil {
 				fmt.Println("🚨Failed to pull image [Docker.ImagePull]:", ref)
+				errChan <- err
+				<-semaphore
+				return
 			}
 			defer func(reader io.ReadCloser) {
 				_ = reader.Close()

--- a/docker_executor/models.go
+++ b/docker_executor/models.go
@@ -67,18 +67,14 @@ type TemplatePrincipalRes struct {
 
 // TryExecutorReq is the request body for POST /executor/try
 type TryExecutorReq struct {
-	SessionId       string                `json:"sessionId" binding:"required"`
 	LocalTemplateId string                `json:"localTemplateId" binding:"required"`
 	Source          string                `json:"source"` // "image" (default) or "path"
 	ImageRef        *DockerImageReference `json:"imageRef"`
 	Path            string                `json:"path"`
 	Template        TemplateVersionRes    `json:"template" binding:"required"`
-	MergerId        string                `json:"mergerId" binding:"required"`
 }
 
 // TryExecutorRes is the response for POST /executor/try
 type TryExecutorRes struct {
-	SessionId     string                `json:"sessionId"`
-	BlobVolume    DockerVolumeReference `json:"blobVolume"`
-	SessionVolume DockerVolumeReference `json:"sessionVolume"`
+	BlobVolume DockerVolumeReference `json:"blobVolume"`
 }

--- a/docker_executor/try_executor.go
+++ b/docker_executor/try_executor.go
@@ -3,7 +3,6 @@ package docker_executor
 import (
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -11,9 +10,6 @@ import (
 var httpClient = &http.Client{
 	Timeout: 5 * time.Second,
 }
-
-// sessionMutex protects session volume creation from race conditions
-var sessionMutex sync.Mutex
 
 type TryExecutor struct {
 	Docker  DockerClient
@@ -37,30 +33,20 @@ func (e *TryExecutor) TrySetup() (TryExecutorRes, []error) {
 		return TryExecutorRes{}, errs
 	}
 
-	// 2. Create session volume (fail if exists)
-	// Note: Session volume is intentionally not cleaned up on partial failure
-	// to allow users to retry or inspect the state for debugging purposes.
-	sessionVol, errs := e.createSessionVolume()
-	if len(errs) > 0 {
-		return TryExecutorRes{}, errs
-	}
-
-	// 3. Pull missing images
+	// 2. Pull missing images
 	errs = e.pullMissingImages()
 	if len(errs) > 0 {
 		return TryExecutorRes{}, errs
 	}
 
-	// 4. Warm resolvers
+	// 3. Warm resolvers
 	errs = e.warmResolvers()
 	if len(errs) > 0 {
 		return TryExecutorRes{}, errs
 	}
 
 	return TryExecutorRes{
-		SessionId:     e.Request.SessionId,
-		BlobVolume:    blobVol,
-		SessionVolume: sessionVol,
+		BlobVolume: blobVol,
 	}, nil
 }
 
@@ -115,7 +101,7 @@ func (e *TryExecutor) populateBlobFromPath(blobVol DockerVolumeReference) error 
 	cc := DockerContainerReference{
 		CyanId:    e.Request.LocalTemplateId,
 		CyanType:  "copy-helper",
-		SessionId: e.Request.SessionId,
+		SessionId: "",
 	}
 	fmt.Println("📂 Copying files from path:", e.Request.Path)
 	return e.Docker.CreateContainerWithCopyMount(cc, e.Request.Path, blobVol)
@@ -163,36 +149,6 @@ func (e *TryExecutor) populateBlobFromImage(blobVol DockerVolumeReference) error
 	fmt.Println("✅ Blob extraction completed")
 
 	return nil
-}
-
-func (e *TryExecutor) createSessionVolume() (DockerVolumeReference, []error) {
-	sessionVol := DockerVolumeReference{
-		CyanId:    e.Request.LocalTemplateId,
-		SessionId: e.Request.SessionId,
-	}
-
-	// Use mutex to ensure atomic check-and-create for session collision detection
-	sessionMutex.Lock()
-	defer sessionMutex.Unlock()
-
-	// Check if exists (collision detection)
-	volumes, err := e.Docker.ListVolumes()
-	if err != nil {
-		return sessionVol, []error{err}
-	}
-
-	for _, v := range volumes {
-		if v.CyanId == e.Request.LocalTemplateId && v.SessionId == e.Request.SessionId {
-			return sessionVol, []error{fmt.Errorf("session volume already exists: session collision")}
-		}
-	}
-
-	fmt.Println("📦 Creating session volume:", DockerVolumeToString(sessionVol))
-	if err := e.Docker.CreateVolume(sessionVol); err != nil {
-		return sessionVol, []error{err}
-	}
-
-	return sessionVol, nil
 }
 
 func (e *TryExecutor) pullMissingImages() []error {


### PR DESCRIPTION
## Summary

- Remove session volume management from try executor — the try endpoint no longer creates or returns session volumes, simplifying the request/response contract
- Remove `SessionId` and `MergerId` fields from `TryExecutorReq`, and `SessionId`/`SessionVolume` from `TryExecutorRes`
- Fix nil pointer dereference in `PullImages` when `ImagePull` fails — return early from goroutine instead of passing nil reader to `io.Copy` and `Close`

## Changes

- `docker_executor/models.go` — Simplified request/response types
- `docker_executor/try_executor.go` — Removed session volume creation logic and mutex
- `docker_executor/docker.go` — Early return on pull failure to prevent panic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image-pull error handling so failures are reported immediately and resources are released to avoid leaks.

* **Refactor**
  * Simplified executor setup and API payloads by removing session-scoped lifecycle and returning only necessary volume information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->