### PR TITLE
fix(executor): unzip container name collision in parallel sessions

### DIFF
--- a/docker_executor/models.go
+++ b/docker_executor/models.go
@@ -67,6 +67,7 @@ type TemplatePrincipalRes struct {
 
 // TryExecutorReq is the request body for POST /executor/try
 type TryExecutorReq struct {
+	SessionId       string                `json:"session_id" binding:"required"`
 	LocalTemplateId string                `json:"localTemplateId" binding:"required"`
 	Source          string                `json:"source"` // "image" (default) or "path"
 	ImageRef        *DockerImageReference `json:"imageRef"`

--- a/docker_executor/try_executor.go
+++ b/docker_executor/try_executor.go
@@ -121,7 +121,7 @@ func (e *TryExecutor) populateBlobFromImage(blobVol DockerVolumeReference) error
 	cc := DockerContainerReference{
 		CyanId:    e.Request.LocalTemplateId,
 		CyanType:  "unzip",
-		SessionId: "",
+		SessionId: e.Request.SessionId,
 	}
 
 	fmt.Println("📦 Extracting blob from image:", DockerImageToString(blobImage))

--- a/spec/CU-86ewypcwt/ticket.md
+++ b/spec/CU-86ewypcwt/ticket.md
@@ -1,0 +1,55 @@
+# Ticket: CU-86ewypcwt
+
+- **Type**: Bug
+- **Status**: backlog
+- **URL**: https://app.clickup.com/t/86ewypcwt
+- **Parent**: none
+- **Assignee**: Adelphi Liong (adelphi@atomi.cloud)
+
+## Description
+
+Bug
+
+Parallel cyan test sessions collide on unzip container name, causing all but the first session to fail with a Docker container name conflict.
+
+Error (every failing test)
+
+failed to start unzip container: Conflict. The container name "/cyan-unzip-b2f2cd5913934a6abb9130654a50de8f" is already in use
+
+Root Cause
+
+In boron/docker_executor/try_executor.go:121-125, the unzip container is created with SessionId: "":
+
+cc := DockerContainerReference{
+CyanId: e.Request.LocalTemplateId,
+CyanType: "unzip",
+SessionId: "", // <-- should be e.Request.SessionId
+}
+
+The naming function in domain_model.go:48-56 already supports session-scoped names — if SessionId is non-empty, it appends it:
+
+if container.SessionId == "" {
+return "cyan-" + container.CyanType + "-" + templateVersionId
+}
+return "cyan-" + container.CyanType + "-" + templateVersionId + "-" + container.SessionId
+
+Since all parallel test cases share the same LocalTemplateId (generated once during warmup) but have unique SessionIds, the container name collides.
+
+Fix
+
+One-line change in boron/docker_executor/try_executor.go:124:
+
+// Before
+SessionId: "",
+// After
+SessionId: e.Request.SessionId,
+
+No breakage risk — the unzip container is ephemeral (created, used, removed in a defer). The naming function already handles both formats. Cleanup uses in-memory DockerContainerReference structs, not name lookups.
+
+Reproduction
+
+cyan test template -c http://localhost:9000 --parallel 10
+
+## Comments
+
+No comments on this ticket.

--- a/spec/CU-86ewypcwt/v1/plans/plan-1.md
+++ b/spec/CU-86ewypcwt/v1/plans/plan-1.md
@@ -1,0 +1,31 @@
+# Plan 1: Fix unzip container SessionId
+
+## File
+
+`docker_executor/try_executor.go`
+
+## Change
+
+Line 124: change `SessionId: ""` to `SessionId: e.Request.SessionId`
+
+```go
+// Before
+cc := DockerContainerReference{
+    CyanId:    e.Request.LocalTemplateId,
+    CyanType:  "unzip",
+    SessionId: "",
+}
+
+// After
+cc := DockerContainerReference{
+    CyanId:    e.Request.LocalTemplateId,
+    CyanType:  "unzip",
+    SessionId: e.Request.SessionId,
+}
+```
+
+## Verification
+
+- `go build ./...` passes
+- Container naming in `domain_model.go:48-56` already handles non-empty `SessionId`
+- Defer cleanup at line 135-138 uses same `cc` reference — works correctly

--- a/spec/CU-86ewypcwt/v1/task-spec.md
+++ b/spec/CU-86ewypcwt/v1/task-spec.md
@@ -1,0 +1,39 @@
+# Task Spec: Fix unzip container name collision in parallel try sessions
+
+## Problem
+
+When running `cyan test template` with `--parallel > 1`, all try sessions for the same template generate the same unzip container name because `SessionId` is hardcoded to `""`. Docker requires unique container names, so only the first session succeeds — all others fail with:
+
+```
+Conflict. The container name "/cyan-unzip-..." is already in use
+```
+
+## Root Cause
+
+In `docker_executor/try_executor.go:124`, the `populateBlobFromImage()` function creates a `DockerContainerReference` with `SessionId: ""`. The naming function in `domain_model.go:48-56` generates the same container name for all sessions sharing the same `LocalTemplateId`:
+
+```go
+// try_executor.go:121-125
+cc := DockerContainerReference{
+    CyanId:    e.Request.LocalTemplateId,
+    CyanType:  "unzip",
+    SessionId: "",  // <-- bug: should be e.Request.SessionId
+}
+```
+
+## Fix
+
+Change `SessionId: ""` to `SessionId: e.Request.SessionId` on line 124 of `docker_executor/try_executor.go`.
+
+The naming function already supports session-scoped names — non-empty `SessionId` is appended to the container name.
+
+## Safety
+
+- The unzip container is ephemeral (created, used, removed in a defer at line 135-138)
+- Cleanup uses the same `cc` struct reference, so it resolves correctly
+- The blob volume intentionally shares `SessionId: ""` across sessions (it checks for existence and reuses)
+- No API or interface changes
+
+## Out of Scope
+
+- `populateBlobFromPath()` copy-helper container (line 104) also uses `SessionId: ""` — separate concern, less common collision scenario


### PR DESCRIPTION
## Summary
- Add `SessionId` field to `TryExecutorReq` struct
- Use `e.Request.SessionId` for the unzip container name in `populateBlobFromImage()`
- Prevents Docker container name collision when running parallel try sessions

## Problem
Parallel `cyan test template` sessions all generated the same unzip container name (`/cyan-unzip-{templateId}`), causing all but the first to fail with `Conflict. The container name is already in use`.

## Fix
The naming function in `domain_model.go` already supports session-scoped names — the `SessionId` was just never passed through. Now the container name becomes `/cyan-unzip-{templateId}-{sessionId}`, making each session unique.

CU-86ewypcwt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved a critical race condition affecting parallel test session execution. When running multiple concurrent test sessions simultaneously, container naming collisions would occur, resulting in Docker conflicts and test failures. Session identifiers are now properly utilized to generate unique container names for each parallel session, enabling reliable and conflict-free concurrent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->